### PR TITLE
Fix remote code execution #1

### DIFF
--- a/www/tilt.php
+++ b/www/tilt.php
@@ -1,5 +1,5 @@
 <?php
-	$output = shell_exec('/home/pi/servo-pi/drive-servo.py 1 ' . $_GET['position']);
+	$output = shell_exec('/home/pi/servo-pi/drive-servo.py 1 ' . escapeshellarg($_GET['position']));
 	// 2>&1
 ?>
 


### PR DESCRIPTION
Passing unsanitized user input into the shell_exec function leads to remote code execution.

In this instance, to execute the `id` command, one would send a request such as the following:

```
GET /tilt.php?position=;id
```

Checking history, [a similar issue was previously reported](https://github.com/recantha/camera-pi/pull/4)

A similar issue also exists [in this file](https://github.com/recantha/camera-pi/blob/master/www/take_photo.php), however I am leaving fixing that as a learning exercise for you.
